### PR TITLE
add interfaces/options/video.pn, sys.messages[18], and Video button from Sound options panel

### DIFF
--- a/interfaces/options/video.pn
+++ b/interfaces/options/video.pn
@@ -1,36 +1,10 @@
 fullscreen:  true
 items:
-	music-during-action:
+	fullscreen:
 		type:    "checkbox"
 		bounds:  {left: 100, top: 111, right: 300, bottom: 121}
-		label:   "Music During Action"
-		hue:     "indigo"
-		style:   "large"
-	music-during-interlude:
-		type:    "checkbox"
-		bounds:  {left: 100, top: 144, right: 300, bottom: 154}
-		label:   "Music During Interlude"
-		hue:     "indigo"
-		style:   "large"
-	volume-up:
-		type:     "button"
-		bounds:   {left: 397, top: 111, right: 557, bottom: 121}
-		label:    "Volume Up"
-		gamepad:  "UP"
-		hue:      "pale-purple"
-		style:    "large"
-	volume-down:
-		type:     "button"
-		bounds:   {left: 397, top: 176, right: 557, bottom: 186}
-		label:    "Volume Down"
-		gamepad:  "DOWN"
-		hue:      "pale-purple"
-		style:    "large"
-	speak-network-messages:
-		type:    "checkbox"
-		bounds:  {left: 100, top: 176, right: 300, bottom: 186}
-		label:   "Speak Network Messages"
-		hue:     "sky-blue"
+		label:   "Fullscreen"
+		hue:     "pale-purple"
 		style:   "large"
 
 	cancel:
@@ -50,11 +24,11 @@ items:
 		hue:      "pale-green"
 		style:    "large"
 
-	video-control:
+	options:
 		type:    "button"
 		bounds:  {left: 420, top: 377, right: 580, bottom: 387}
-		label:   "Video"
-		key:     "V"
+		label:   "Sound"
+		key:     "S"
 		hue:     "aqua"
 		style:   "large"
 	key-controls:
@@ -82,15 +56,9 @@ items:
 		bounds:   {left: 35, top: 456, right: 615, bottom: 556}
 		picture:  "gui/tablet/bottom"
 
-	sound-options:
+	video-options:
 		type:    "rect"
 		bounds:  {left: 53, top: 92, right: 588, bottom: 293}
-		label:   "Sound Options"
-		hue:     "pale-purple"
+		label:   "Video Options"
+		hue:     "indigo"
 		style:   "large"
-	volume:
-		type:    "rect"
-		bounds:  {left: 73, top: 235, right: 567, bottom: 276}
-		label:   "VOLUME"
-		hue:     "pale-purple"
-		style:   "small"


### PR DESCRIPTION
There is currently a "fullscreen" option that can only be configured via `$HOME/.local/share/games/antares/config.pn`. This PR adds an option screen where fullscreen can be controlled from the in-game settings.

In the future, maybe we can add resolution or scaling settings here, too.

The "Options" button on the main splash actually takes you to the Sound Control panel. There is a new "Video" button in the bottom right cluster:
<img alt="ares_sound" src="https://github.com/arescentral/antares-data/assets/7785285/68cd40f3-6bcb-41dc-b1ac-92c739d89dfa">


From there, choosing "Video" shows a new pane that didn't exist before:
<img alt="ares_video" src="https://github.com/arescentral/antares-data/assets/7785285/1f1e98ff-48cb-432c-aabb-f062a1b1279a">


If the fullscreen setting has changed to a different value since game launch, a "restart required" message appears, with similar styling to the "conflict" message on the Key Controls options. The message state will be correct even if you change screens and return.
<img alt="ares_video_changed" src="https://github.com/arescentral/antares-data/assets/7785285/87767504-7c76-4681-a124-9d0f7bad8473">

